### PR TITLE
Issue 9: service 'ports' must be a mapping not an array

### DIFF
--- a/standalone-minion/docker-compose.yaml
+++ b/standalone-minion/docker-compose.yaml
@@ -19,8 +19,8 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
-  ports:
-    - "1162:1162/udp"
-    - "1514:1514/udp"
-    - "4729:4729/udp"
-    - "8102:8102/tcp"
+    ports:
+      - "1162:1162/udp"
+      - "1514:1514/udp"
+      - "4729:4729/udp"
+      - "8102:8102/tcp"


### PR DESCRIPTION
fixes #9 