### PR TITLE
fixed hostnames issue 18

### DIFF
--- a/full-stack/container-fs/horizon/opt/opennms-overlay/confd/horizon-config.yaml
+++ b/full-stack/container-fs/horizon/opt/opennms-overlay/confd/horizon-config.yaml
@@ -17,7 +17,7 @@ opennms:
     storebyforeignsource: true
 
   cassandra:
-    hostnames: cassandra-01
+    hostname: cassandra-01
     keyspace: newts
     port: 9042
     username: cassandra

--- a/minimal-newts/container-fs/opt/opennms-overlay/confd/horizon-config.yaml
+++ b/minimal-newts/container-fs/opt/opennms-overlay/confd/horizon-config.yaml
@@ -17,7 +17,7 @@ opennms:
     storebyforeignsource: true
 
   cassandra:
-    hostnames: cassandra-01
+    hostname: cassandra-01
     keyspace: newts
     port: 9042
     username: cassandra


### PR DESCRIPTION
addressing https://github.com/opennms-forge/stack-play/issues/18

stack-play\minimal-newts\container-fs\opt\opennms-overlay\confd\horizon-config.yaml
cassandra:
hostnames: cassandra-01

should be (no s on hostnames)

cassandra:
hostname: cassandra-01