### PR TITLE
feat: Run PostgreSQL databases with 200 connections instead 100

### DIFF
--- a/full-stack/docker-compose.yaml
+++ b/full-stack/docker-compose.yaml
@@ -51,6 +51,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data:delegated
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/helm-flow-stack/docker-compose.yaml
+++ b/helm-flow-stack/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data:delegated
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/minimal-bmp/container-fs/opt/opennms/deploy/minimal-horizon/docker-compose.yaml
+++ b/minimal-bmp/container-fs/opt/opennms/deploy/minimal-horizon/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/minimal-flows/docker-compose.yaml
+++ b/minimal-flows/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data:delegated
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/minimal-horizon-cortex/docker-compose.yaml
+++ b/minimal-horizon-cortex/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/minimal-horizon-watchtower/docker-compose.yaml
+++ b/minimal-horizon-watchtower/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/minimal-horizon/docker-compose.yaml
+++ b/minimal-horizon/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/minimal-minion-grpc/docker-compose.yaml
+++ b/minimal-minion-grpc/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/minimal-minion-kafka/docker-compose.yaml
+++ b/minimal-minion-kafka/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/minimal-minion/docker-compose.yaml
+++ b/minimal-minion/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/minimal-newts/docker-compose.yaml
+++ b/minimal-newts/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/multiple-minions-activemq/docker-compose.yaml
+++ b/multiple-minions-activemq/docker-compose.yaml
@@ -45,6 +45,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data
+    command: ["postgres", "-N", "200"]
     networks:
       net-core:
         ipv4_address: 192.168.1.10

--- a/standalone-postgres/docker-compose.yaml
+++ b/standalone-postgres/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - data-postgres:/var/lib/postgresql/data
+    command: ["postgres", "-N", "200"]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s


### PR DESCRIPTION
Start PostgreSQL server with 200 instead of 100 connection to avoid error message introduced in https://opennms.atlassian.net/browse/NMS-15852

Resolve: #27 