### PR TITLE
Added Fixes for Cassandra 

### DIFF
--- a/full-stack/container-fs/horizon/opt/opennms-overlay/confd/horizon-config.yaml
+++ b/full-stack/container-fs/horizon/opt/opennms-overlay/confd/horizon-config.yaml
@@ -22,3 +22,4 @@ opennms:
     port: 9042
     username: cassandra
     password: cassandra
+    datacenter: opennms-lab

--- a/full-stack/docker-compose.yaml
+++ b/full-stack/docker-compose.yaml
@@ -92,6 +92,12 @@ services:
       JMX_HOST: 127.0.0.1
     volumes:
       - data-cassandra-01:/var/lib/cassandra
+    healthcheck:
+      test: [ "CMD-SHELL", "cqlsh -e 'describe cluster'" ]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 60s
 
   horizon:
     image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-bleeding}
@@ -100,8 +106,12 @@ services:
     sysctls:
       net.ipv4.ping_group_range: "0 429496729"
     depends_on:
-      - database
-      - es01
+      database:
+        condition: service_healthy
+      cassandra-01:
+        condition: service_healthy
+      es01:
+        condition: service_healthy
     environment:
       TZ: ${TIMEZONE:-America/New_York}
       REPLICATION_FACTOR: 1

--- a/full-stack/docker-compose.yaml
+++ b/full-stack/docker-compose.yaml
@@ -73,7 +73,7 @@ services:
       - data-es01:/usr/share/elasticsearch/data
       - ./container-fs/es01/plugins:/usr/share/elasticsearch/plugins
     healthcheck:
-      test: curl http://localhost:9200 >/dev/null; if [[ $$? == 52 ]]; then echo 0; else echo 1; fi
+      test: [ "CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1" ]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/minimal-newts/container-fs/opt/opennms-overlay/confd/horizon-config.yaml
+++ b/minimal-newts/container-fs/opt/opennms-overlay/confd/horizon-config.yaml
@@ -22,3 +22,4 @@ opennms:
     port: 9042
     username: cassandra
     password: cassandra
+    datacenter: opennms-lab

--- a/minimal-newts/docker-compose.yaml
+++ b/minimal-newts/docker-compose.yaml
@@ -41,14 +41,22 @@ services:
       JMX_HOST: 127.0.0.1
     volumes:
       - data-cassandra-01:/var/lib/cassandra
+    healthcheck:
+      test: [ "CMD-SHELL", "cqlsh -e 'describe cluster'" ]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 60s
 
   horizon:
     image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-bleeding}
     container_name: horizon
     hostname: horizon
-    depends_on: 
-      - database
-      - cassandra-01
+    depends_on:
+      database:
+        condition: service_healthy
+      cassandra-01:
+        condition: service_healthy
     sysctls:
       net.ipv4.ping_group_range: "0 429496729"
     environment:


### PR DESCRIPTION
Added fixes to both the `full-stack` and `minimal-newts` Docker stacks. The fixes include:

- Added `datacenter` to the `horizon-config.yaml` files. 

This was needed because the newest Cassandra driver requires a datacenter name. If you have the timeseries set to `newts`, it won't start without it. 

- Added health check for Cassandra. 

I also added this because I updated the Horizon section in the `docker-compose.yaml`, so that it waits for a "service_healthy" status to come back for both the database and Cassandra. I ran into issues where OpenNMS would attempt to start before Cassandra had started. This was causing start up issues for OpenNMS because the "newts" keyspace didn't exist. The `entrypoint.sh` script will only initialize the "newts" keyspace if the `configured` files doesn't exist in `$OPENNMS_HOME/etc`. With OpenNMS starting up before Cassandra, it never had the chance to initialize that keyspace and so it would exit. 

The above issues have been fixed with my changes. 