### PR TITLE
feat: add victorialogs-e2e-lab stack

### DIFF
--- a/victorialogs-e2e-lab/README.md
+++ b/victorialogs-e2e-lab/README.md
@@ -1,0 +1,129 @@
+# victorialogs-e2e-lab
+
+End-to-end lab for OpenNMS flow persistence in [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/).
+The pipeline: [nl6](https://github.com/labmonkeys-space/nl6) simulates devices exporting IPFIX → OpenNMS Horizon (telemetryd + VictoriaLogs flow persistence) → VictoriaLogs → Grafana with the OpenNMS plugin and the Flow Deep Dive dashboard.
+
+The VictoriaLogs flow persistence is not released yet.
+It lives on the [`ronny-poc/victorialogs-flows`](https://github.com/OpenNMS/opennms/tree/ronny-poc/victorialogs-flows) branch, so you build the `opennms/horizon:37.0.0-SNAPSHOT` container image locally first.
+
+## Prerequisites
+
+- Docker with Compose v2
+- JDK 21 and around 30 GB free disk for the OpenNMS source build
+- `expect` on the host if you want to use the `karaf.exp` helper
+
+## 1. Build the Horizon container image from the branch
+
+```bash
+git clone https://github.com/OpenNMS/opennms.git
+cd opennms
+git checkout ronny-poc/victorialogs-flows
+
+# Compile and assemble (takes a while, go get coffee)
+./compile.pl -DskipTests
+./assemble.pl -Dopennms.home=/opt/opennms -DskipTests
+
+# Build the container image from the assembled tarball
+cd opennms-container/core
+make image
+```
+
+Verify the image exists:
+
+```bash
+docker images opennms/horizon
+# REPOSITORY        TAG               ...
+# opennms/horizon   37.0.0-SNAPSHOT   ...
+```
+
+The tag comes from the version in the branch `pom.xml`.
+If it differs from `37.0.0-SNAPSHOT`, adjust the `opennms` image tag in `compose.yml`.
+
+## 2. Start the stack
+
+```bash
+docker compose up -d
+```
+
+Wait until OpenNMS reports healthy (first start takes a few minutes):
+
+```bash
+docker compose ps opennms
+```
+
+## 3. Route the simulated device subnet
+
+nl6 gives each simulated device its own source IP in `10.10.0.0/16`.
+OpenNMS needs a route to that subnet through the nl6 container so SNMP polling and flow attribution work:
+
+```bash
+docker compose run --rm addroute
+```
+
+The route lives in the OpenNMS container's network namespace and dies with every `opennms` restart.
+Re-run the command after each restart.
+
+## 4. Create simulated devices exporting IPFIX
+
+Create 10 devices that export IPFIX to the OpenNMS telemetryd listener on port 9999 (the `Multi-UDP-9999` listener is enabled by default):
+
+```bash
+OPENNMS_IP=$(docker compose exec nl6 getent hosts opennms | awk '{print $1}')
+curl -s -X POST http://localhost:8080/api/v1/devices \
+  -H 'Content-Type: application/json' \
+  -d "{\"start_ip\":\"10.10.0.1\",\"device_count\":10,\"netmask\":\"24\",\"flow\":{\"collector\":\"${OPENNMS_IP}:9999\",\"protocol\":\"ipfix\"}}"
+```
+
+Check the export status:
+
+```bash
+curl -s http://localhost:8080/api/v1/flows/status
+```
+
+## 5. Provision the devices as OpenNMS nodes
+
+`onms-provision.sh` reads the devices from the nl6 API and imports them as a requisition:
+
+```bash
+./onms-provision.sh --import
+```
+
+## 6. Verify
+
+Health check through the Karaf shell (expects "Connecting to VictoriaLogs (Flows): Success"):
+
+```bash
+./karaf.exp 'opennms:health-check'
+```
+
+Flows arriving through the REST API:
+
+```bash
+curl -su admin:admin 'http://localhost:8980/opennms/rest/flows/count?start=-900000'
+curl -su admin:admin 'http://localhost:8980/opennms/rest/flows/exporters?start=-900000'
+```
+
+Rows ingested into VictoriaLogs:
+
+```bash
+curl -s http://localhost:9428/metrics | grep vl_rows_ingested_total
+```
+
+Grafana at <http://localhost:3001> (admin/admin) is fully provisioned: OpenNMS datasources, the OpenNMS app plugin, and the Flow Deep Dive dashboard in the "OpenNMS" folder.
+Top applications, conversations, and hosts panels should fill up after a few minutes of flow traffic.
+
+## Endpoints
+
+| Service      | URL                            | Credentials |
+|--------------|--------------------------------|-------------|
+| OpenNMS      | <http://localhost:8980/opennms> | admin/admin |
+| Grafana      | <http://localhost:3001>         | admin/admin |
+| VictoriaLogs | <http://localhost:9428>         | none        |
+| nl6 API      | <http://localhost:8080>         | none        |
+| Karaf SSH    | localhost:8101                  | admin/admin |
+
+## Lab notes
+
+- `overlay/etc/org.opennms.features.flows.persistence.victorialogs.cfg` points the persistence and query service at `http://victorialogs:9428`.
+- `overlay/etc/org.opennms.features.flows.persistence.elastic.cfg` sets `skipElasticsearchPersistence=true`. There is no Elasticsearch in this lab, and without it the unconfigured Elasticsearch repository throws on every batch and blocks the VictoriaLogs persister.
+- `RESULTS.md` documents the verified end-to-end pass this lab is based on, including findings that need fixes on the branch.

--- a/victorialogs-e2e-lab/RESULTS.md
+++ b/victorialogs-e2e-lab/RESULTS.md
@@ -1,0 +1,36 @@
+# E2E Verification Results — 2026-08-05
+
+Branch: `ronny-poc/victorialogs-flows` @ f7bc8692b42, image `opennms/horizon:37.0.0-SNAPSHOT` (local build).
+Stack: VictoriaLogs v1.52.0, Grafana (host port **3001**), nl6 10 devices IPFIX -> `opennms:9999`.
+
+Grafana history: E2E PASS was verified on `opennms/helm:12.0.1` (Grafana 12.1.2). Afterwards migrated to stock `grafana/grafana-oss:latest` (13.0.2) + `GF_INSTALL_PLUGINS` + `./grafana/provisioning/` (datasources, app enable, plugin-dashboard file provider), mirroring opennms-playground `include/grafana.yml`. Re-verified on the stock stack: plugin 12.0.1 enabled, 4 datasources provisioned, Flow Deep Dive imported (folder "OpenNMS"), `rest/flows` count + top-N apps answer through the datasource proxy (note: Grafana 13 needs the `/api/datasources/proxy/uid/<uid>/` route).
+
+## Gates
+
+- **Gate 0 (first-ever container load): PASS.** `opennms-flows` feature resolved, victorialogs bundle 434 started, blueprint parsed, query service registered at ranking 1000.
+- **Gate 1: PASS.** Health check "Connecting to VictoriaLogs (Flows): Success" (cfg overlay read, VL reachable).
+
+## Probes
+
+1. **Sender**: nl6 exporting from 10 per-device source IPs (10.10.0.1-10) to collector 192.168.107.4:9999, 226,560 records cumulative.
+2. **Store**: `/insert/jsonline` requests flowing, 0 errors; `vl_rows_ingested_total{type="jsonline"} 111360`, all `vl_rows_dropped_total` = 0. Documents carry full `netflow.*` set, real ifIndexes, direction. Count-gap vs sender = the two outage windows below, no loss in steady state.
+3. **REST**: `rest/flows/count` = 51k+ (served by VictoriaLogsFlowQueryService); `rest/flows/exporters` returns all 10 provisioned nodes after requisition import (48 SNMP interfaces/node via routed SNMP).
+4. **Dashboard**: app plugin enabled, 3 datasources green via Grafana proxy; Flow Deep Dive auto-imported at `/d/c35cc96b-da0b-4fa9-a947-6f699e24ab78/`; top-5 applications (https/http/domain/ssh classified + Unknown), conversations, hosts series all return correct data. **Visual pass confirmed by Ronny 2026-08-05: WORKS.**
+
+## E2E VERDICT: PASS (2026-08-05)
+
+## Findings (need branch/upstream fixes)
+
+1. **PipelineImpl persister loop has no exception isolation** (`features/flows/processing/.../PipelineImpl.java:139-141`). The unconfigured Elasticsearch repository (default `localhost:9200`) throws on every batch and starves the VictoriaLogs persister. VictoriaLogs got ZERO flows until Elasticsearch persistence was explicitly disabled. Fix: per-persister try/catch (log + continue). This also means: co-deployed ES outage today silently loses the same flows for every other persister.
+2. **Hot-applying `skipElasticsearchPersistence=true` did not take effect**: after blueprint reload, the pipeline kept invoking the destroyed elastic repository via a stale proxy ("Request execution cancelled"). Restart required. Same reluctant-rebinding family as documented for the query side.
+
+## Lab workarounds encoded in this directory
+
+- `overlay/etc/org.opennms.features.flows.persistence.elastic.cfg` — `skipElasticsearchPersistence=true` (no ES in lab; see finding 1).
+- Device-subnet route dies with every opennms restart. Re-add with the compose one-shot:
+  `docker compose run --rm addroute`
+- Host port 8080 is shadowed by a local Python process -> use the nl6 container IP for its REST API. Grafana on host port 3001.
+
+## Visual checklist (confirmed 2026-08-05)
+
+http://localhost:3001/d/c35cc96b-da0b-4fa9-a947-6f699e24ab78/ — verified working end to end by visual inspection.

--- a/victorialogs-e2e-lab/compose.yml
+++ b/victorialogs-e2e-lab/compose.yml
@@ -1,0 +1,90 @@
+# E2E verification lab: nl6 -> OpenNMS (ronny-poc/victorialogs-flows) -> VictoriaLogs -> Grafana Flow Deep Dive
+# See README.md for build and run instructions.
+services:
+  database:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      retries: 12
+
+  victorialogs:
+    image: victoriametrics/victoria-logs:v1.52.0
+    command: ["-storageDataPath=/victoria-logs-data"]
+    volumes:
+      - vldata:/victoria-logs-data
+    ports:
+      - "127.0.0.1:9428:9428"
+
+  opennms:
+    image: opennms/horizon:37.0.0-SNAPSHOT
+    depends_on:
+      database:
+        condition: service_healthy
+      victorialogs:
+        condition: service_started
+    command: ["-s"]
+    cap_add:
+      - NET_ADMIN
+    environment:
+      POSTGRES_HOST: database
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      OPENNMS_DBNAME: opennms
+      OPENNMS_DBUSER: opennms
+      OPENNMS_DBPASS: opennms
+    volumes:
+      - ./overlay/etc:/opt/opennms-etc-overlay
+    ports:
+      - "8980:8980"
+      - "8101:8101"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8980/opennms/login.jsp"]
+      interval: 30s
+      timeout: 5s
+      retries: 40
+
+  grafana:
+    image: grafana/grafana-oss:latest
+    environment:
+      TZ: UTC
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_INSTALL_PLUGINS: opennms-opennms-app,victoriametrics-logs-datasource
+      GF_FEATURE_TOGGLES_ENABLE: nestedFolders
+    volumes:
+      - data-grafana:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    ports:
+      - "3001:3000"
+
+  nl6:
+    image: ghcr.io/labmonkeys-space/nl6:latest
+    cap_add:
+      - NET_ADMIN
+      - SYS_ADMIN
+    devices:
+      - /dev/net/tun
+    ports:
+      - "8080:8080"
+
+  # One-shot: adds the nl6 device-subnet route inside the opennms netns.
+  # The route dies with every opennms restart - rerun this afterwards:
+  #   docker compose run --rm addroute
+  addroute:
+    image: alpine
+    profiles: [tools]
+    network_mode: service:opennms
+    cap_add:
+      - NET_ADMIN
+    depends_on:
+      opennms:
+        condition: service_started
+    command: sh -c "ip route replace 10.10.0.0/16 via $$(getent hosts nl6 | awk '{print $$1}') && ip route show | grep 10.10"
+
+volumes:
+  vldata:
+  data-grafana:

--- a/victorialogs-e2e-lab/grafana/provisioning/dashboards/opennms.yml
+++ b/victorialogs-e2e-lab/grafana/provisioning/dashboards/opennms.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+# Imports the dashboards shipped inside the OpenNMS app plugin (Flow Deep Dive et al.)
+providers:
+  - name: opennms-plugin-dashboards
+    folder: OpenNMS
+    type: file
+    options:
+      path: /var/lib/grafana/plugins/opennms-opennms-app/dashboards

--- a/victorialogs-e2e-lab/grafana/provisioning/datasources/opennms.yml
+++ b/victorialogs-e2e-lab/grafana/provisioning/datasources/opennms.yml
@@ -1,0 +1,32 @@
+apiVersion: 1
+
+datasources:
+  - name: OpenNMS flow
+    type: opennms-flow-datasource
+    access: proxy
+    url: http://opennms:8980/opennms
+    basicAuth: true
+    basicAuthUser: admin
+    secureJsonData:
+      basicAuthPassword: admin
+    isDefault: true
+  - name: OpenNMS performance
+    type: opennms-performance-datasource
+    access: proxy
+    url: http://opennms:8980/opennms
+    basicAuth: true
+    basicAuthUser: admin
+    secureJsonData:
+      basicAuthPassword: admin
+  - name: OpenNMS entity
+    type: opennms-entity-datasource
+    access: proxy
+    url: http://opennms:8980/opennms
+    basicAuth: true
+    basicAuthUser: admin
+    secureJsonData:
+      basicAuthPassword: admin
+  - name: VictoriaLogs
+    type: victoriametrics-logs-datasource
+    access: proxy
+    url: http://victorialogs:9428

--- a/victorialogs-e2e-lab/grafana/provisioning/plugins/opennms.yml
+++ b/victorialogs-e2e-lab/grafana/provisioning/plugins/opennms.yml
@@ -1,0 +1,5 @@
+apiVersion: 1
+
+apps:
+  - type: opennms-opennms-app
+    org_id: 1

--- a/victorialogs-e2e-lab/karaf.exp
+++ b/victorialogs-e2e-lab/karaf.exp
@@ -1,0 +1,12 @@
+#!/usr/bin/expect -f
+# Run a single Karaf shell command against OpenNMS on localhost:8101 (admin/admin)
+set timeout 30
+set cmd [lindex $argv 0]
+spawn ssh -p 8101 \
+  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAuthentication=no \
+  admin@localhost $cmd
+expect {
+    -re "(?i)password:" { send "admin\r"; exp_continue }
+    eof
+}

--- a/victorialogs-e2e-lab/onms-provision.sh
+++ b/victorialogs-e2e-lab/onms-provision.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ronny Trommer <ronny@no42.org>
+# SPDX-License-Identifier: Apache-2.0
+#
+# onms-provision.sh — generate and import an OpenNMS requisition from nl6 devices
+#
+# Generic across every example: it reads whatever devices the running nl6
+# instance currently exposes (NL6_URL/api/v1/devices), so the same script
+# provisions any fabric (5-stage-clos, large-clos, …). Run it after the
+# example's own nl6-provision.sh has created the devices.
+#
+# Usage:
+#   ./onms-provision.sh                  # generate XML to stdout
+#   ./onms-provision.sh --import         # generate and import into OpenNMS
+#   ./onms-provision.sh --import --dry-run  # print what would be imported
+#
+set -euo pipefail
+
+NL6_URL="${NL6_URL:-http://localhost:8080}"
+# One knob for scheme + host + port + context path. Switch http/https or point
+# at a remote OpenNMS by setting just this — e.g. OPENNMS_BASE_URL=https://onms:443/opennms
+OPENNMS_BASE_URL="${OPENNMS_BASE_URL:-http://localhost:8980/opennms}"
+OPENNMS_BASE_URL="${OPENNMS_BASE_URL%/}"   # tolerate a trailing slash
+OPENNMS_USER="${OPENNMS_USER:-admin}"
+OPENNMS_PASS="${OPENNMS_PASS:-admin}"
+FOREIGN_SOURCE="${FOREIGN_SOURCE:-nl6-inventory}"
+MINION_LOCATION="${MINION_LOCATION:-Default}"
+GNMI_SERVICE="${GNMI_SERVICE:-gNMI-Telemetry}"
+OC_PORT="${OC_PORT:-9339}"
+OC_MODE="${OC_MODE:-gnmi}"
+OC_PATHS="${OC_PATHS:-/interfaces/interface/state/counters,/components/component/state}"
+
+IMPORT=false
+DRY_RUN=false
+
+usage() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Generate an OpenNMS requisition XML from nl6 simulated devices.
+
+Options:
+  --import      Upload the requisition to OpenNMS and trigger an import
+  --dry-run     With --import: print the XML without uploading
+  -h|--help     Show this message
+
+Environment variables (all optional):
+  NL6_URL           nl6 base URL             (default: http://localhost:8080)
+  OPENNMS_BASE_URL  OpenNMS base URL incl. scheme, host, port, context path
+                    (default: http://localhost:8980/opennms)
+  OPENNMS_USER      OpenNMS username         (default: admin)
+  OPENNMS_PASS      OpenNMS password         (default: admin)
+  FOREIGN_SOURCE    Requisition foreign-source name (default: nl6-inventory)
+  MINION_LOCATION   Minion location label    (default: Default)
+
+gNMI / OpenConfig telemetry (per-node requisition metadata, consumed by the
+OpenConfigConnector in telemetryd-configuration.xml):
+  GNMI_SERVICE      Monitored service that activates the connector (default: gNMI-Telemetry)
+  OC_PORT           Device gNMI/gRPC port    (default: 9339, the nl6 gNMI port)
+  OC_MODE           Stream mode: gnmi | jti  (default: gnmi)
+  OC_PATHS          Comma-separated OpenConfig subscription paths
+                    (default: /interfaces/interface/state/counters,/components/component/state)
+
+Examples:
+  $0 --import                                        # upload and trigger import
+  $0 --import --dry-run                              # preview XML without importing
+  OPENNMS_BASE_URL=https://onms:443/opennms $0 --import
+  MINION_LOCATION=site-a $0 --import
+EOF
+}
+
+if [[ $# -eq 0 ]]; then usage; exit 0; fi
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --import)   IMPORT=true; shift ;;
+    --dry-run)  DRY_RUN=true; shift ;;
+    -h|--help)  usage; exit 0 ;;
+    *) echo "Error: unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# ── fetch devices + generate requisition XML ──────────────────────────────────
+# Python handles both the HTTP fetch (urllib) and XML generation to avoid
+# any shell-level HTTP client interception.
+
+# Values reach Python via the environment, not by interpolating into the heredoc
+# (note the quoted 'PYEOF'): the shell never expands inside the Python source, so
+# a quote or backtick in any of these vars can't break out into code injection.
+requisition=$(
+  NL6_URL="${NL6_URL}" \
+  FOREIGN_SOURCE="${FOREIGN_SOURCE}" \
+  MINION_LOCATION="${MINION_LOCATION}" \
+  GNMI_SERVICE="${GNMI_SERVICE}" \
+  OC_PORT="${OC_PORT}" \
+  OC_MODE="${OC_MODE}" \
+  OC_PATHS="${OC_PATHS}" \
+  python3 - <<'PYEOF'
+import json, os, ssl, sys
+import urllib.request
+from datetime import datetime, timezone
+from xml.sax.saxutils import quoteattr
+
+url          = os.environ["NL6_URL"] + "/api/v1/devices"
+foreign_source = os.environ["FOREIGN_SOURCE"]
+location     = os.environ["MINION_LOCATION"]
+gnmi_service = os.environ["GNMI_SERVICE"]
+oc_port      = os.environ["OC_PORT"]
+oc_mode      = os.environ["OC_MODE"]
+oc_paths     = os.environ["OC_PATHS"]
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+try:
+    with urllib.request.urlopen(url, context=ctx) as resp:
+        data = json.load(resp)
+except Exception as e:
+    print(f"Error fetching {url}: {e}", file=sys.stderr)
+    sys.exit(1)
+
+if not data.get("success"):
+    print(f"API error: {data.get('message', 'unknown')}", file=sys.stderr)
+    sys.exit(1)
+
+devices = data["data"]
+ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+lines = []
+lines.append('<?xml version="1.0" encoding="UTF-8"?>')
+lines.append(f'<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import"')
+lines.append(f'              date-stamp="{ts}"')
+lines.append(f'              foreign-source="{foreign_source}">')
+
+for device in devices:
+    node_id = device["id"]
+    ip      = device["ip"]
+    lines.append(f'    <node location="{location}" foreign-id="{node_id}" node-label="{node_id}">')
+    lines.append(f'        <interface ip-addr="{ip}" status="1" snmp-primary="P">')
+    lines.append( '            <monitored-service service-name="ICMP"/>')
+    lines.append( '            <monitored-service service-name="SNMP"/>')
+    lines.append(f'            <monitored-service service-name={quoteattr(gnmi_service)}/>')
+    lines.append( '        </interface>')
+    # Geolocation asset fields (from the nl6 device API). Exact coordinates win
+    # when present; the city name is emitted as an OpenNMS geocoder fallback and for
+    # readability. Asset elements precede meta-data per the requisition schema.
+    lat = device.get("latitude")
+    lng = device.get("longitude")
+    if lat is not None and lng is not None:
+        try:
+            lat_f, lng_f = float(lat), float(lng)
+            lines.append(f'        <asset name="latitude" value={quoteattr(f"{lat_f}")}/>')
+            lines.append(f'        <asset name="longitude" value={quoteattr(f"{lng_f}")}/>')
+        except (TypeError, ValueError):
+            pass
+    loc = device.get("location")
+    if loc:
+        # quoteattr() escapes commas/non-ASCII (e.g. "Tōkyō, Japan").
+        lines.append(f'        <asset name="city" value={quoteattr(str(loc))}/>')
+    # OpenConfig connector config (per node); overrides telemetryd-configuration.xml defaults.
+    # quoteattr() escapes XML metacharacters — gNMI paths legitimately contain [name="..."].
+    lines.append(f'        <meta-data context="requisition" key="oc.port" value={quoteattr(oc_port)}/>')
+    lines.append(f'        <meta-data context="requisition" key="oc.mode" value={quoteattr(oc_mode)}/>')
+    lines.append(f'        <meta-data context="requisition" key="oc.paths" value={quoteattr(oc_paths)}/>')
+    lines.append( '    </node>')
+
+lines.append('</model-import>')
+print("\n".join(lines))
+PYEOF
+)
+
+# ── output or import ──────────────────────────────────────────────────────────
+
+if ! $IMPORT; then
+  echo "$requisition"
+  exit 0
+fi
+
+node_count=$(echo "$requisition" | grep -c '<node ')
+echo "Importing ${node_count} devices into OpenNMS as foreign-source '${FOREIGN_SOURCE}'..."
+
+if $DRY_RUN; then
+  echo "--- dry-run: requisition XML ---"
+  echo "$requisition"
+  exit 0
+fi
+
+opennms_base="${OPENNMS_BASE_URL}"
+# --fail-with-body: exit non-zero on an HTTP >= 400 (auth failure, bad XML,
+# duplicate foreign-source, …) while still printing the response body, so a
+# rejected upload/import reports the error instead of a misleading "done".
+curl_opts=(-sk --fail-with-body -u "${OPENNMS_USER}:${OPENNMS_PASS}" -H "Content-Type: application/xml" -H "Accept: application/xml")
+
+tmp=$(mktemp /tmp/onms-provision.XXXXXX.xml)
+chmod 600 "$tmp"
+trap 'rm -f "$tmp"' EXIT
+printf '%s' "$requisition" > "$tmp"
+
+echo -n "Uploading requisition  ... "
+if ! curl "${curl_opts[@]}" -X POST -d "@${tmp}" \
+     "${opennms_base}/rest/requisitions"; then
+  echo "FAILED (see response above)" >&2
+  exit 1
+fi
+echo "done"
+
+echo -n "Triggering import      ... "
+if ! curl "${curl_opts[@]}" -X PUT \
+     "${opennms_base}/rest/requisitions/${FOREIGN_SOURCE}/import?rescanExisting=false"; then
+  echo "FAILED (see response above)" >&2
+  exit 1
+fi
+echo "done"
+

--- a/victorialogs-e2e-lab/overlay/etc/org.opennms.features.flows.persistence.elastic.cfg
+++ b/victorialogs-e2e-lab/overlay/etc/org.opennms.features.flows.persistence.elastic.cfg
@@ -1,0 +1,3 @@
+# No Elasticsearch in this lab. Without this, the unconfigured elastic repository throws
+# on every batch and PipelineImpl aborts its persister loop before VictoriaLogs runs.
+skipElasticsearchPersistence=true

--- a/victorialogs-e2e-lab/overlay/etc/org.opennms.features.flows.persistence.victorialogs.cfg
+++ b/victorialogs-e2e-lab/overlay/etc/org.opennms.features.flows.persistence.victorialogs.cfg
@@ -1,0 +1,3 @@
+url=http://victorialogs:9428
+skipVictoriaLogsPersistence=false
+skipVictoriaLogsQueries=false


### PR DESCRIPTION
Adds a new stack: **victorialogs-e2e-lab** — an end-to-end lab for OpenNMS flow persistence in VictoriaLogs. Pipeline: nl6 simulated devices exporting IPFIX → OpenNMS Horizon (telemetryd + VictoriaLogs flow persistence) → VictoriaLogs → Grafana Flow Deep Dive dashboard.

The VictoriaLogs flow persistence is not released yet; the README documents the exact steps to build the `opennms/horizon:37.0.0-SNAPSHOT` image from the [`ronny-poc/victorialogs-flows`](https://github.com/OpenNMS/opennms/tree/ronny-poc/victorialogs-flows) branch and run the lab locally, including device provisioning (`onms-provision.sh`), routing for the simulated device subnet, and verification steps.

`RESULTS.md` records the verified E2E pass (2026-08-05) this lab is based on, including two findings that need fixes on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)